### PR TITLE
Development install and run updates

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ Latest version of this app for osx can download from [here](https://github.com/T
 
 ```sh
 $ npm install
-$ npm run start
+$ npm start
 ```
 
 ## License

--- a/package.json
+++ b/package.json
@@ -37,6 +37,7 @@
     "electron-connect": "^0.3.5",
     "electron-debug": "^0.5.1",
     "electron-packager": "^5.2.1",
+    "electron-prebuilt": "^0.37.2",
     "eslint-config-makotot": "0.0.6",
     "eslint-plugin-react": "^3.16.1",
     "gulp": "^3.9.0",


### PR DESCRIPTION
I added `electron-prebuilt` to the devDependencies, so that the electron binary is now installed with the `npm install` command, instead of needing to be installed globally, or added to path.

I also updated the development command in README.md, `npm` has shortcuts for `start`, so the `run` part of the command isn't required.
